### PR TITLE
Adding default concrete class to AggregateFactoryInterface

### DIFF
--- a/src/Broadway/EventStorageServiceProvider.php
+++ b/src/Broadway/EventStorageServiceProvider.php
@@ -10,6 +10,11 @@ class EventStorageServiceProvider extends ServiceProvider
             'Nwidart\LaravelBroadway\EventStore\EventStoreFactory',
             'Nwidart\LaravelBroadway\EventStore\Broadway\BroadwayEventStoreFactory'
         );
+        
+        $this->app->bind(
+            'Broadway\EventSourcing\AggregateFactory\AggregateFactoryInterface',
+            'Broadway\EventSourcing\AggregateFactory\PublicConstructorAggregateFactory'
+        );
 
         $this->app->bind('Broadway\EventStore\EventStoreInterface', function ($app) {
             $driver = $app['config']->get('broadway.event-store.driver');


### PR DESCRIPTION
In most cases, poeple will use PublicConstructorAggregateFactory, so this is some sensible default