### PR TITLE
Fix error for instantiation of Elasticsearch 2.0 client

### DIFF
--- a/src/ReadModel/Broadway/Drivers/Elasticsearch.php
+++ b/src/ReadModel/Broadway/Drivers/Elasticsearch.php
@@ -22,6 +22,6 @@ class Elasticsearch implements Driver
     {
         $config = $this->config->get('broadway.read-model-connections.elasticsearch.config');
 
-        return new Client($config);
+        return ClientBuilder::fromConfig($config);
     }
 }


### PR DESCRIPTION
PHP Elasticsearch 2.0 has changed the instantiating of the client. With the current code you will get
`ErrorException: Argument 1 passed to Elasticsearch\Client::__construct() must be an instance of Elasticsearch\Transport, array given`