### PR TITLE
Create the correct version of the Elasticsearch client

### DIFF
--- a/src/ReadModel/Broadway/Drivers/Elasticsearch.php
+++ b/src/ReadModel/Broadway/Drivers/Elasticsearch.php
@@ -1,6 +1,5 @@
 <?php namespace Nwidart\LaravelBroadway\ReadModel\Broadway\Drivers;
 
-use Elasticsearch\Client;
 use Nwidart\LaravelBroadway\ReadModel\Driver;
 
 class Elasticsearch implements Driver
@@ -22,6 +21,11 @@ class Elasticsearch implements Driver
     {
         $config = $this->config->get('broadway.read-model-connections.elasticsearch.config');
 
-        return ClientBuilder::fromConfig($config);
+        // elasticsearch v2.0 using builder
+        if (class_exists(\Elasticsearch\ClientBuilder::class)) {
+            return \Elasticsearch\ClientBuilder::fromConfig($config);
+        }
+        // elasticsearch v1
+        return new \Elasticsearch\Client($config);
     }
 }


### PR DESCRIPTION
Elasticsearch changed the way how to create the client between version 1
and 2. We should handle both cases to be independent from the version.