### PR TITLE
Make the stream decorator and enrichers available

### DIFF
--- a/src/Broadway/MetadataEnricherServiceProvider.php
+++ b/src/Broadway/MetadataEnricherServiceProvider.php
@@ -1,0 +1,30 @@
+<?php namespace Nwidart\LaravelBroadway\Broadway;
+
+use Broadway\EventSourcing\EventStreamDecoratorInterface;
+use Broadway\EventSourcing\MetadataEnrichment\MetadataEnrichingEventStreamDecorator;
+use Illuminate\Support\ServiceProvider;
+use Nwidart\LaravelBroadway\Registries\MetaDataEnricherRegistry;
+
+/**
+ * Class MetadataEnricherServiceProvider
+ *
+ * @package Nwidart\LaravelBroadway\Broadway
+ * @author Stefano Kowalke <blueduck@mailbox.org>
+ */
+class MetadataEnricherServiceProvider extends ServiceProvider
+{
+
+    /**
+     * Register the MetadataEnrichingEventStreamDecorator
+     */
+    public function register()
+    {
+        $this->app->singleton(EventStreamDecoratorInterface::class, function () {
+            return new MetadataEnrichingEventStreamDecorator();
+        });
+
+        $this->app->singleton('laravelbroadway.enricher.registry', function ($app) {
+            return new MetaDataEnricherRegistry($app[EventStreamDecoratorInterface::class]);
+        });
+    }
+}

--- a/src/LaravelBroadwayServiceProvider.php
+++ b/src/LaravelBroadwayServiceProvider.php
@@ -15,6 +15,7 @@ class LaravelBroadwayServiceProvider extends ServiceProvider
         $this->app->register('Nwidart\LaravelBroadway\Broadway\EventStorageServiceProvider');
         $this->app->register('Nwidart\LaravelBroadway\Broadway\SupportServiceProvider');
         $this->app->register('Nwidart\LaravelBroadway\Broadway\ReadModelServiceProvider');
+        $this->app->register('Nwidart\LaravelBroadway\Broadway\MetadataEnricherServiceProvider');
     }
 
     /**

--- a/src/Registries/MetaDataEnricherRegistry.php
+++ b/src/Registries/MetaDataEnricherRegistry.php
@@ -1,0 +1,47 @@
+<?php namespace Nwidart\LaravelBroadway\Registries;
+
+use Broadway\EventSourcing\MetadataEnrichment\MetadataEnrichingEventStreamDecorator;
+
+/**
+ * Class MetaDataEnricherRegistry
+ *
+ * @package Nwidart\LaravelBroadway\Registries
+ * @author Stefano Kowalke <blueduck@mailbox.org>
+ */
+class MetaDataEnricherRegistry extends BaseRegistry implements Registry
+{
+    /**
+     * @var MetadataEnrichingEventStreamDecorator $eventStreamDecorator
+     */
+    private $eventStreamDecorator;
+
+    /**
+     * @param MetadataEnrichingEventStreamDecorator $eventStreamDecorator
+     */
+    public function __construct(MetadataEnrichingEventStreamDecorator $eventStreamDecorator)
+    {
+        $this->eventStreamDecorator = $eventStreamDecorator;
+    }
+
+    /**
+     * Subscribe the given array of command handlers on the command bus
+     * @param array $enrichers
+     */
+    public function subscribe($enrichers)
+    {
+        $enrichers = $this->isTraversable($enrichers) ? $enrichers : [$enrichers];
+
+        foreach ($enrichers as $enricher) {
+            $this->eventStreamDecorator->registerEnricher($enricher);
+        }
+    }
+
+
+    /**
+     * @return MetadataEnrichingEventStreamDecorator
+     */
+    public function getEventStreamDecorator()
+    {
+        return $this->eventStreamDecorator;
+    }
+}


### PR DESCRIPTION
Broadway uses Decorators and Enrichers to add metadata to an event.
This CR makes it very easy to register Enrichers on the Decorator.

See more information in the readme.md