### PR TITLE
Change UUID database column type to CHAR

### DIFF
--- a/migrations/2015_01_20_181911_create_event_store_table.php
+++ b/migrations/2015_01_20_181911_create_event_store_table.php
@@ -22,7 +22,7 @@ class CreateEventStoreTable extends Migration
         Schema::create($this->eventStoreTableName, function (Blueprint $table) {
             $table->increments('id');
 
-            $table->string('uuid', 36);
+            $table->char('uuid', 36);
             $table->integer('playhead')->unsigned();
             $table->text('metadata');
             $table->text('payload');


### PR DESCRIPTION
`CHAR` has some performance advantages over `VARCHAR`. Also Laravel uses `CHAR(36)` for it's new `uuid` type introduced in [v5.2](https://github.com/laravel/framework/commit/c10f65bd75ac58f22e85f64768951d13fb11d0fb).

If you later decide to upgrade the migration schema to Laravel's `uuid` type, the underlying database schema wouldn't change.