### PR TITLE
Use driver param instead of the connection name

### DIFF
--- a/src/EventStore/Broadway/Drivers/Dbal.php
+++ b/src/EventStore/Broadway/Drivers/Dbal.php
@@ -51,7 +51,7 @@ class Dbal implements Driver
         $connectionParams['dbname'] = $connectionParams['database'];
         $connectionParams['user'] = $connectionParams['username'];
         unset($connectionParams['database'], $connectionParams['username']);
-        $connectionParams['driver'] = "pdo_$driver";
+        $connectionParams['driver'] = "pdo_".$connectionParams['driver'];
 
         return $connectionParams;
     }


### PR DESCRIPTION
Found this out when attempting to test with a different connection than my normal one.
