### PR TITLE
Add support for Laravel 6 LTS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "doctrine/dbal": "~2.5",
     "broadway/broadway": "~1.0.0",
     "broadway/event-store-dbal": "^0.1.2",
-    "illuminate/support": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*|5.8.*"
+    "illuminate/support": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*|5.8.*|6.*"
   },
   "require-dev": {
     "phpunit/phpunit": "4.0"


### PR DESCRIPTION
Hi @nWidart,

I don't see a reason not to allow Laravel 6. Is it possible for support to be added?